### PR TITLE
Dockerfile compatible for Raspberry Pi arm64v8

### DIFF
--- a/build_rpi64.Dockerfile
+++ b/build_rpi64.Dockerfile
@@ -1,0 +1,59 @@
+# syntax = docker/dockerfile:1.2
+
+# Builds a light Alpine image from sources.
+# Requires Docker buildkit.
+
+ARG RUST_IMAGE=arm64v8/rust:slim-buster
+FROM $RUST_IMAGE AS builder
+RUN rustup install nightly
+
+# Fetch dependencies.
+RUN apt-get update && apt-get install -y libssl-dev pkg-config
+
+# Copy sources.
+COPY . /build
+WORKDIR /build
+
+# Build.
+RUN \
+  --mount=type=cache,target=/build/target \
+  # See https://doc.rust-lang.org/cargo/guide/cargo-home.html
+  --mount=type=cache,target=/usr/local/cargo/registry \
+  --mount=type=cache,target=/usr/local/cargo/git \
+  cargo +nightly build --bin nimiq-client && cp /build/target/debug/nimiq-client /build/
+
+# Light stage.
+FROM ubuntu:20.04
+
+# Install dependencies.
+RUN apt-get update && apt-get install -y libssl1.1
+
+# Run as unprivileged user.
+RUN adduser --disabled-password --home /home/nimiq --shell /bin/bash --uid 1001 nimiq
+USER nimiq
+
+# Pull image from builder.
+COPY --chown=root:root --from=builder /build/nimiq-client /usr/local/bin/nimiq-client
+COPY ./scripts/docker_*.sh /home/nimiq/
+
+WORKDIR /home/nimiq
+
+# Create .nimiq, so that it has the right permissions. docker-compose might want to create this
+# because we want to use this as a volume, but we don't want this directory to be owned by root.
+RUN mkdir -p /home/nimiq/.nimiq
+VOLUME /home/nimiq/.nimiq
+
+EXPOSE 8443/tcp 8648/tcp
+
+#ENTRYPOINT ["/usr/local/bin/nimiq-client"]
+ENTRYPOINT [ "/bin/bash" ]
+CMD [ "/home/nimiq/docker_run.sh" ]
+
+
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+LABEL \
+  org.opencontainers.image.title="Nimiq core-rs-albatross" \
+  org.opencontainers.image.description="Rust implementation of the Nimiq Blockchain Core Albatross Branch (Buildkit Ubuntu image)" \
+  org.opencontainers.image.url="https://github.com/nimiq/core-rs-albatross" \
+  org.opencontainers.image.vendor="Nimiq Foundation" \
+  org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.

## What's in this pull request?

> build_ubuntu.Dockerfile being able to run in Raspberry Pi OS arm64v8 (aarch64) 

**Operating System installed**: `Linux raspberrypi 5.10.17-v8+ #1403 SMP PREEMPT Mon Feb 22 11:37:54 GMT 2021 aarch64 GNU/Linux` (Buster)
**Required** Latest beta build from Raspberry Pi downloads: https://downloads.raspberrypi.org/raspios_arm64/images/

**Optional dependencies

**: installing libseccomp2 with buster backports ([Source](https://blog.samcater.com/fix-workaround-rpi4-docker-libseccomp2-docker-20/))
```
# Get signing keys to verify the new packages, otherwise they will not install
rpi ~$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138

# Add the Buster backport repository to apt sources.list
rpi ~$ echo 'deb http://httpredir.debian.org/debian buster-backports main contrib non-free' | sudo tee -a /etc/apt/sources.list.d/debian-backports.list

rpi ~$ sudo apt update
rpi ~$ sudo apt install libseccomp2 -t buster-backports
```

Instead of `rustlang/rust:nightly-slim` as Rust image that is used to build Devlab, `arm64v8/rust:slim-buster` and installed a nightly version of it since slim-buster is stable release of Rust and doesn't seem to work with compiling library that required nightly build.